### PR TITLE
Use TCP keep-alive probing on the event stream connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN set -x \
 
 
 ENV HAPROXY_MAJOR=1.7 \
-    HAPROXY_VERSION=1.7.2 \
-    HAPROXY_MD5=7330b36f3764ebe409e9305803dc30e2
+    HAPROXY_VERSION=1.7.5 \
+    HAPROXY_MD5=ed84c80cb97852d2aa3161ed16c48a1c
 
 COPY requirements.txt /marathon-lb/
 

--- a/marathon_lb.py
+++ b/marathon_lb.py
@@ -112,7 +112,7 @@ class MarathonService(object):
         self.bindOptions = None
         self.bindAddr = '*'
         self.groups = frozenset()
-        self.mode = 'tcp'
+        self.mode = None
         self.balance = 'roundrobin'
         self.healthCheck = healthCheck
         self.labels = {}
@@ -382,10 +382,13 @@ def config(apps, groups, bind_http_https, ssl_certs, templater,
         logger.debug("frontend at %s:%d with backend %s",
                      app.bindAddr, app.servicePort, backend)
 
-        # if the app has a hostname set force mode to http
-        # otherwise recent versions of haproxy refuse to start
-        if app.hostname:
-            app.mode = 'http'
+        # If app has HAPROXY_{n}_MODE set, use that setting.
+        # Otherwise use 'http' if HAPROXY_{N}_VHOST is set, and 'tcp' if not.
+        if app.mode is None:
+            if app.hostname:
+                app.mode = 'http'
+            else:
+                app.mode = 'tcp'
 
         if app.authUser:
             userlist_head = templater.haproxy_userlist_head(app)

--- a/utils.py
+++ b/utils.py
@@ -157,6 +157,9 @@ class CurlHttpEventStream(object):
         self.curl.setopt(pycurl.URL, url)
         self.curl.setopt(pycurl.ENCODING, 'gzip')
         self.curl.setopt(pycurl.CONNECTTIMEOUT, 10)
+        self.curl.setopt(pycurl.TCP_KEEPALIVE, 1)
+        self.curl.setopt(pycurl.TCP_KEEPIDLE, 50)
+        self.curl.setopt(pycurl.TCP_KEEPINTVL, 50)
         self.curl.setopt(pycurl.WRITEDATA, self.received_buffer)
         if auth and type(auth) is DCOSAuth:
             auth.refresh_auth_header()

--- a/utils.py
+++ b/utils.py
@@ -158,8 +158,8 @@ class CurlHttpEventStream(object):
         self.curl.setopt(pycurl.ENCODING, 'gzip')
         self.curl.setopt(pycurl.CONNECTTIMEOUT, 10)
         self.curl.setopt(pycurl.TCP_KEEPALIVE, 1)
-        self.curl.setopt(pycurl.TCP_KEEPIDLE, 50)
-        self.curl.setopt(pycurl.TCP_KEEPINTVL, 50)
+        self.curl.setopt(pycurl.TCP_KEEPIDLE, 15)
+        self.curl.setopt(pycurl.TCP_KEEPINTVL, 5)
         self.curl.setopt(pycurl.WRITEDATA, self.received_buffer)
         if auth and type(auth) is DCOSAuth:
             auth.refresh_auth_header()


### PR DESCRIPTION
If you are connecting to the event stream through some load balancing device,
there is a good chance your connection will get dropped after some time if no
traffic is crossing the wire. In the case of an AWS ELB, this interval is 60
seconds. Enable TCP keepalive and set the idle time and time between probes to
50 seconds to prevent connection dropping.

(Also, merge latest upstream master)